### PR TITLE
Fix encoding headers

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#coding=utf-
+# coding=utf-8
 
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import  pyqtSignal

--- a/main_sky.py
+++ b/main_sky.py
@@ -1,4 +1,4 @@
-#coding=utf-
+# coding=utf-8
 
 # import test
 from PyQt5 import QtCore, QtGui, QtWidgets


### PR DESCRIPTION
## Summary
- add missing `utf-8` in encoding headers for `main.py` and `main_sky.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683fd6e6da348329814f0527510d2715